### PR TITLE
More Infra Fixes

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -12,6 +12,8 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -16,5 +18,6 @@ jobs:
       - name: Publish package to pypi
         run: ./nox.sh -s publish -- pypi
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,10 +93,11 @@ source = [
 branch = true
 parallel = true
 source = ["pysparkplug"]
+omit = ["*_pb2.py"]
 
 [tool.coverage.report]
 show_missing = true
-fail_under = 46
+fail_under = 48
 
 [tool.check-wheel-contents]
 toplevel = "pysparkplug"


### PR DESCRIPTION
## Summary

More infrastructural fixes.

### Why?

We want to get CICD working.

### How?

- Omit protobuf autogen code from coverage tests.
- Add github token to publish Github Action workflow step.
- Add write permission to github token to create/edit the Github release.

## Checklist

Most checks are automated, but a few aren't, so make sure to go through and tick them off, even if they don't apply. This checklist is here to help, not deter you. Remember, "Slow is smooth, and smooth is fast".

- [X] **Unit tests**
  - Every input should have a test for it.
  - Every potential raised exception should have a test ensuring it is raised.
- [X] **Documentation**
  - New functions/classes/etc. must be added to `docs/api.rst`.
  - Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
  - The appropriate entry in `CHANGELOG.md` has been included in the "Unreleased" section, i.e. "Added", "Changed", "Deprecated", "Removed", "Fixed", or "Security".
- [X] **Future work**
  - Future work should be documented in the contributor guide, i.e. `.github/CONTRIBUTING.md`.

If you have any questions not answered by a quick readthrough of the [contributor guide](https://pysparkplug.mattefay.com/en/latest/contributor_guide.html), add them to this PR and submit it.
