### PR TITLE
Prep for release 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes for `pysparkplug` will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Changelog](http://keepachangelog.com/).
 
+## 0.3.1. (2024-02-13)
+
+### Changed
+- Pysparkplug is not compatible with the new 2.0 releasee of Paho, the underlying Python MQTT client.
+
 ## 0.3.0 (2024-01-13)
 
 ### Added

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,6 +4,7 @@ Configuration file for the Sphinx documentation builder.
 For a full list of confiuration options, see the documentation:
 https://www.sphinx-doc.org/en/master/usage/configuration.html
 """
+
 # pylint: disable=invalid-name
 
 import datetime

--- a/requirements/black.txt
+++ b/requirements/black.txt
@@ -4,7 +4,7 @@
 #
 #    ./nox.sh -s update_requirements
 #
-black==23.12.1
+black==24.2.0
     # via -r /root/pysparkplug/requirements/black.in
 click==8.1.7
     # via black
@@ -14,5 +14,5 @@ packaging==23.2
     # via black
 pathspec==0.12.1
     # via black
-platformdirs==4.1.0
+platformdirs==4.2.0
     # via black

--- a/requirements/coverage.txt
+++ b/requirements/coverage.txt
@@ -4,5 +4,5 @@
 #
 #    ./nox.sh -s update_requirements
 #
-coverage[toml]==7.4.0
+coverage[toml]==7.4.1
     # via -r /root/pysparkplug/requirements/coverage.in

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -8,9 +8,9 @@ alabaster==0.7.16
     # via sphinx
 babel==2.14.0
     # via sphinx
-beautifulsoup4==4.12.2
+beautifulsoup4==4.12.3
     # via furo
-certifi==2023.11.17
+certifi==2024.2.2
     # via requests
 charset-normalizer==3.3.2
     # via requests
@@ -18,7 +18,7 @@ docutils==0.20.1
     # via
     #   myst-parser
     #   sphinx
-furo==2023.9.10
+furo==2024.1.29
     # via -r /root/pysparkplug/requirements/docs.in
 idna==3.6
     # via requests
@@ -32,7 +32,7 @@ markdown-it-py==3.0.0
     # via
     #   mdit-py-plugins
     #   myst-parser
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via jinja2
 mdit-py-plugins==0.4.0
     # via myst-parser
@@ -89,5 +89,5 @@ sphinxcontrib-serializinghtml==1.1.10
     # via sphinx
 sphinxext-opengraph==0.9.1
     # via -r /root/pysparkplug/requirements/docs.in
-urllib3==2.1.0
+urllib3==2.2.0
     # via requests

--- a/requirements/mypy.txt
+++ b/requirements/mypy.txt
@@ -4,9 +4,9 @@
 #
 #    ./nox.sh -s update_requirements
 #
-argcomplete==3.2.1
+argcomplete==3.2.2
     # via nox
-colorlog==6.8.0
+colorlog==6.8.2
     # via nox
 distlib==0.3.8
     # via virtualenv
@@ -24,15 +24,15 @@ packaging==23.2
     #   nox
 paho-mqtt==1.6.1
     # via -r /root/pysparkplug/requirements/requirements.txt
-platformdirs==4.1.0
+platformdirs==4.2.0
     # via virtualenv
 protobuf==4.25.2
     # via -r /root/pysparkplug/requirements/requirements.txt
-types-colorama==0.4.15.20240106
+types-colorama==0.4.15.20240205
     # via -r /root/pysparkplug/requirements/mypy.in
 types-paho-mqtt==1.6.0.20240106
     # via -r /root/pysparkplug/requirements/mypy.in
-types-protobuf==4.24.0.20240106
+types-protobuf==4.24.0.20240129
     # via -r /root/pysparkplug/requirements/mypy.in
 typing-extensions==4.9.0
     # via mypy

--- a/requirements/packaging.txt
+++ b/requirements/packaging.txt
@@ -10,7 +10,7 @@ attrs==23.2.0
     # via check-wheel-contents
 build==1.0.3
     # via -r /root/pysparkplug/requirements/packaging.in
-certifi==2023.11.17
+certifi==2024.2.2
     # via requests
 cffi==1.16.0
     # via cryptography
@@ -20,7 +20,7 @@ check-wheel-contents==0.6.0
     # via -r /root/pysparkplug/requirements/packaging.in
 click==8.1.7
     # via check-wheel-contents
-cryptography==41.0.7
+cryptography==42.0.2
     # via secretstorage
 docutils==0.20.1
     # via readme-renderer
@@ -30,7 +30,7 @@ importlib-metadata==7.0.1
     # via
     #   keyring
     #   twine
-jaraco-classes==3.3.0
+jaraco-classes==3.3.1
     # via keyring
 jeepney==0.8.0
     # via
@@ -54,9 +54,9 @@ pkginfo==1.9.6
     # via twine
 pycparser==2.21
     # via cffi
-pydantic==2.5.3
+pydantic==2.6.1
     # via check-wheel-contents
-pydantic-core==2.14.6
+pydantic-core==2.16.2
     # via pydantic
 pygments==2.17.2
     # via
@@ -78,13 +78,13 @@ rich==13.7.0
     # via twine
 secretstorage==3.3.3
     # via keyring
-twine==4.0.2
+twine==5.0.0
     # via -r /root/pysparkplug/requirements/packaging.in
 typing-extensions==4.9.0
     # via
     #   pydantic
     #   pydantic-core
-urllib3==2.1.0
+urllib3==2.2.0
     # via
     #   requests
     #   twine

--- a/requirements/publish.txt
+++ b/requirements/publish.txt
@@ -6,13 +6,13 @@
 #
 build==1.0.3
     # via -r /root/pysparkplug/requirements/publish.in
-certifi==2023.11.17
+certifi==2024.2.2
     # via requests
 cffi==1.16.0
     # via cryptography
 charset-normalizer==3.3.2
     # via requests
-cryptography==41.0.7
+cryptography==42.0.2
     # via secretstorage
 docutils==0.20.1
     # via readme-renderer
@@ -22,7 +22,7 @@ importlib-metadata==7.0.1
     # via
     #   keyring
     #   twine
-jaraco-classes==3.3.0
+jaraco-classes==3.3.1
     # via keyring
 jeepney==0.8.0
     # via
@@ -68,9 +68,9 @@ rich==13.7.0
     # via twine
 secretstorage==3.3.3
     # via keyring
-twine==4.0.2
+twine==5.0.0
     # via -r /root/pysparkplug/requirements/publish.in
-urllib3==2.1.0
+urllib3==2.2.0
     # via
     #   requests
     #   twine

--- a/requirements/pylint.txt
+++ b/requirements/pylint.txt
@@ -4,13 +4,13 @@
 #
 #    ./nox.sh -s update_requirements
 #
-argcomplete==3.2.1
+argcomplete==3.2.2
     # via nox
-astroid==3.0.2
+astroid==3.0.3
     # via pylint
-colorlog==6.8.0
+colorlog==6.8.2
     # via nox
-dill==0.3.7
+dill==0.3.8
     # via pylint
 distlib==0.3.8
     # via virtualenv
@@ -28,7 +28,7 @@ packaging==23.2
     #   nox
 paho-mqtt==1.6.1
     # via -r /root/pysparkplug/requirements/requirements.txt
-platformdirs==4.1.0
+platformdirs==4.2.0
     # via
     #   pylint
     #   virtualenv

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,3 +1,3 @@
-paho-mqtt
+paho-mqtt < 2
 protobuf
 typing-extensions; python_version < "3.11"

--- a/requirements/unit_tests.txt
+++ b/requirements/unit_tests.txt
@@ -4,7 +4,7 @@
 #
 #    ./nox.sh -s update_requirements
 #
-coverage[toml]==7.4.0
+coverage[toml]==7.4.1
     # via -r /root/pysparkplug/requirements/unit_tests.in
 iniconfig==2.0.0
     # via pytest
@@ -14,9 +14,9 @@ packaging==23.2
     #   pytest
 paho-mqtt==1.6.1
     # via -r /root/pysparkplug/requirements/requirements.txt
-pluggy==1.3.0
+pluggy==1.4.0
     # via pytest
 protobuf==4.25.2
     # via -r /root/pysparkplug/requirements/requirements.txt
-pytest==7.4.4
+pytest==8.0.0
     # via -r /root/pysparkplug/requirements/unit_tests.in

--- a/src/pysparkplug/_client.py
+++ b/src/pysparkplug/_client.py
@@ -59,9 +59,11 @@ class Client:
             client_id=client_id,
             clean_session=True,
             protocol=protocol,
-            transport=Transport.WS
-            if isinstance(transport_config, WSConfig)
-            else Transport.TCP,
+            transport=(
+                Transport.WS
+                if isinstance(transport_config, WSConfig)
+                else Transport.TCP
+            ),
             reconnect_on_failure=client_options.reconnect_on_failure,
         )
         self._client.enable_logger(logger)

--- a/src/pysparkplug/_metric.py
+++ b/src/pysparkplug/_metric.py
@@ -84,9 +84,11 @@ class Metric:
             timestamp=metric.timestamp if metric.HasField("timestamp") else None,
             name=metric.name if metric.HasField("name") else None,
             datatype=datatype,
-            value=datatype.decode(getattr(metric, value_field))
-            if value_field is not None
-            else None,
+            value=(
+                datatype.decode(getattr(metric, value_field))
+                if value_field is not None
+                else None
+            ),
             alias=metric.alias if metric.HasField("alias") else None,
             is_historical=metric.is_historical,
             is_transient=metric.is_transient,


### PR DESCRIPTION
## Summary

Prep for release 0.3.1

### Why?

Need to get a release out to handle the broken API of Paho v2.0.

### How?

Update deps, and requirements in various nox sessions.

## Checklist

Most checks are automated, but a few aren't, so make sure to go through and tick them off, even if they don't apply. This checklist is here to help, not deter you. Remember, "Slow is smooth, and smooth is fast".

- [X] **Unit tests**
  - Every input should have a test for it.
  - Every potential raised exception should have a test ensuring it is raised.
- [X] **Documentation**
  - New functions/classes/etc. must be added to `docs/api.rst`.
  - Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
  - The appropriate entry in `CHANGELOG.md` has been included in the "Unreleased" section, i.e. "Added", "Changed", "Deprecated", "Removed", "Fixed", or "Security".
- [X] **Future work**
  - Future work should be documented in the contributor guide, i.e. `.github/CONTRIBUTING.md`.

If you have any questions not answered by a quick readthrough of the [contributor guide](https://pysparkplug.mattefay.com/en/latest/contributor_guide.html), add them to this PR and submit it.
