### PR TITLE
Docs Version Fix

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,4 +11,4 @@ build:
     - asdf plugin add uv
     - asdf install uv latest
     - asdf global uv latest
-    - uv run sphinx-build -T -W -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html
+    - uv run --frozen sphinx-build -T -W -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html

--- a/test/unit_tests/test_datatype.py
+++ b/test/unit_tests/test_datatype.py
@@ -766,10 +766,7 @@ class TestArrayTypes(unittest.TestCase):
         )
         for array, description in test_cases:
             with self.subTest(case=description):
-                encoded = DataType.BOOLEAN_ARRAY.encode(array)
-                print(encoded)
                 decoded = encode_decode(array, DataType.BOOLEAN_ARRAY)
-
                 self.assertEqual(len(decoded), len(array))
                 self.assertEqual(decoded, array)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1087,7 +1087,7 @@ wheels = [
 
 [[package]]
 name = "pysparkplug"
-version = "0.4.1.dev11"
+version = "0.5.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "paho-mqtt" },


### PR DESCRIPTION
## Summary

Fix the version in ReadtheDocs builds.

### Why?

It's currently off by one.

### How?

Keep uv.lock from changing during docs build, leading to the wrong version showing up in the docs
