### PR TITLE
copy _subscriptions so that it can't be altered within the loop

### DIFF
--- a/src/pysparkplug/_client.py
+++ b/src/pysparkplug/_client.py
@@ -168,7 +168,7 @@ class Client:
     def _on_connect(self, rc: int) -> None:
         check_connack_code(rc)
         self._births.clear()
-        for topic, qos in self._subscriptions.items():
+        for topic, qos in list(self._subscriptions.items()):
             self._subscribe(topic=topic, qos=qos)
 
     def disconnect(self) -> None:


### PR DESCRIPTION
## Fix for Dictionary Size Change During Iteration in `_on_connect`

This PR addresses [Issue #20](https://github.com/matteosox/pysparkplug/issues/20), where `_on_connect` in `_client.py` (line 168) fails when multiple clients are running and one client publishes a new topic while another subscribes. The root cause is that `self._subscriptions` is modified during iteration, leading to a `RuntimeError: dictionary changed size during iteration`.

### Fix  
I converted the iterator into a list before iterating over `self._subscriptions`. This ensures that the loop does not reference the dictionary directly, preventing modifications during iteration.

### Changes  
```python
def _on_connect(self, rc: int) -> None:
    check_connack_code(rc)
    self._births.clear()
    for topic, qos in list(self._subscriptions.items()):  # Convert to list to avoid runtime error
        self._subscribe(topic=topic, qos=qos)