### PR TITLE
Change _int_decoder to allow uint32 into smaller types instead of OverflowException

### DIFF
--- a/src/pysparkplug/_datatype.py
+++ b/src/pysparkplug/_datatype.py
@@ -122,10 +122,13 @@ def _int_encoder(value: int, bits: int) -> int:
 
 
 def _int_decoder(value: int, bits: int) -> int:
-    max_val: int = 2**bits
-    if not 0 <= value < max_val:
-        raise OverflowError(f"Int{bits} overflow with value {value}")
-    return value - (max_val if value >= 2 ** (bits - 1) else 0)
+    mask = (1 << bits) - 1  # e.g. 0xFFFF for 16 bits
+    value &= mask  # drop any higher bits
+    sign_bit = 1 << (bits - 1)  # e.g. 0x8000 for 16 bits
+    if value & sign_bit:  # if sign bit is set
+        value -= 1 << bits
+
+    return value
 
 
 def _encode_numeric_array(values: Sequence[float], format_char: str) -> bytes:

--- a/test/unit_tests/test_datatype.py
+++ b/test/unit_tests/test_datatype.py
@@ -134,11 +134,15 @@ class TestScalarTypes(unittest.TestCase):
                         decoded, value, f"Failed to encode/decode {value} with {dtype}"
                     )
 
-    def test_decoder_errors(self) -> None:
-        with self.assertRaises(OverflowError):
-            # too large
-            DataType.INT8.decode(2**9)
+    def test_decoding_sign_extended_values(self):
+        value = -87
+        signExtendedValue = (
+            value & 0xFFFFFFFF  # packed into uint32 for Google Protobuf
+        )
+        decoded = DataType.INT16.decode(signExtendedValue)
+        self.assertEqual(decoded, value)
 
+    def test_decoder_errors(self) -> None:
         with self.assertRaises(ValueError):
             # not enough bytes
             DataType.INT16_ARRAY.decode(b"\x00")


### PR DESCRIPTION
Proposal for opening up the int_decoder logic to decode any value into its desired type instead of throwing an exception. We are hitting this error when decoding messages generated by a third-party Sparkplug device.

## Summary

Handle decoding sign-extended integers instead of throwing an OverflowException

### Why?

We are unable to parse certain messages sent from third-party devices because the _int_decoder method is too restrictive and throws when the value to parse is larger than its datatype’s max value. This makes intuitive sense but it ignores how two’s complement integers can get sign-extended when cast to larger types.

The [SparkplugB protobuf file](https://github.com/Cirrus-Link/Sparkplug/blob/main/sparkplug_b/sparkplug_b.proto#L174C13-L174C19) defines the Metric value as (oneof) UINT32 meaning any INT16 value needs to be encoded as UINT32.

The spec does not require the UINT32 value must be smaller than its associated datatype’s max value which the OverflowException checks for. I don’t think this exception is necessary because a two’s compliment number that gets sign-extended by a publisher to maintain its negative value and then interpreted as a UINT32 can be larger than its datatype’s max value. This is due to encoding and not because of an overflow.

For a concrete example we have a third-party device encoding a negative INT16 which needs to be encoded as UINT32 for the Protobuf layer. The publisher sign-extends smaller integer values up to INT32 before storing them as UINT32.

INT16 = -87 (0xFFA9)
INT32 = -87 (0xFFFFFFA9) - sign-extended to maintain negative value
UINT32 = 4294967209 (0xFFFFFFA9) - value parsed at the Protobuf layer

The _int_decoder then throws because 4294967209 > Int16 max value. 

The _int_decoder method should instead be looking at the bits for the desired type and the sign bit to decode into the actual value.
